### PR TITLE
Update timecard navigation to honor pay period query

### DIFF
--- a/client/src/pages/dashboard.tsx
+++ b/client/src/pages/dashboard.tsx
@@ -54,10 +54,13 @@ export default function Dashboard() {
   const [, setLocation] = useLocation();
 
   const handleNavigateToTimecard = (employeeId: number) => {
+    const payPeriodQuery = currentPayPeriod ? `&payPeriod=${currentPayPeriod.id}` : "";
     if (selectedEmployerId) {
-      setLocation(`/timecards?employer=${selectedEmployerId}&employee=${employeeId}`);
+      setLocation(
+        `/timecards?employer=${selectedEmployerId}&employee=${employeeId}${payPeriodQuery}`
+      );
     } else {
-      setLocation(`/timecards?employee=${employeeId}`);
+      setLocation(`/timecards?employee=${employeeId}${payPeriodQuery}`);
     }
   };
 

--- a/client/src/pages/timecards.tsx
+++ b/client/src/pages/timecards.tsx
@@ -19,13 +19,16 @@ export default function Timecards() {
   const { user } = useAuth();
   // Extract employer and employee IDs directly from the browser URL search params
   const searchParams = new URLSearchParams(window.location.search);
-  const employerParam = searchParams.get('employer');
+  const employerParam = searchParams.get("employer");
   const initialEmployerId = employerParam ? parseInt(employerParam, 10) : null;
-  const employeeParam = searchParams.get('employee');
-  const initialPreSelectedEmployeeId = employeeParam ? parseInt(employeeParam, 10) : null;
+  const employeeParam = searchParams.get("employee");
+  const initialPreSelectedEmployeeId = employeeParam
+    ? parseInt(employeeParam, 10)
+    : null;
+  const payPeriodParam = searchParams.get("payPeriod") || "";
   const [preSelectedEmployeeId] = useState<number | null>(initialPreSelectedEmployeeId);
   const [selectedEmployerId, setSelectedEmployerId] = useState<number | null>(initialEmployerId);
-  const [selectedPayPeriodId, setSelectedPayPeriodId] = useState<string>("");
+  const [selectedPayPeriodId, setSelectedPayPeriodId] = useState<string>(payPeriodParam);
 
   // Fetch employers
   const { data: employers = [] } = useQuery<any[]>({
@@ -57,13 +60,13 @@ export default function Timecards() {
     enabled: !!selectedEmployerId,
   });
 
-  // Set default selected pay period
+  // Set default selected pay period only when no payPeriod parameter was provided
   useEffect(() => {
-    if (payPeriods.length > 0 && !selectedPayPeriodId) {
+    if (!payPeriodParam && payPeriods.length > 0 && !selectedPayPeriodId) {
       const current = payPeriods.find((p: any) => p.isActive) || payPeriods[0];
       setSelectedPayPeriodId(current.id.toString());
     }
-  }, [payPeriods, selectedPayPeriodId]);
+  }, [payPeriods, selectedPayPeriodId, payPeriodParam]);
 
 
 


### PR DESCRIPTION
## Summary
- add `payPeriod` query to timecard navigation from dashboard
- allow `/timecards` to preselect pay period from query string
- avoid overriding selected period unless no period param

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685073f7ed688324b9c16b71e5e96302