### PR TITLE
Add UTC formatting with date-fns-tz

### DIFF
--- a/client/src/lib/dateUtils.ts
+++ b/client/src/lib/dateUtils.ts
@@ -1,10 +1,11 @@
 import { format, differenceInDays, isAfter, isBefore, addDays, startOfDay } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 
 export function formatDate(date: string | Date): string {
   if (!date) return '';
   const dateObj = typeof date === 'string' ? new Date(date) : date;
   if (isNaN(dateObj.getTime())) return '';
-  return format(dateObj, 'MMM dd, yyyy');
+  return formatInTimeZone(dateObj, 'UTC', 'MMM dd, yyyy');
 }
 
 export function formatTime(time: string): string {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
+    "date-fns-tz": "^3.2.0",
     "drizzle-orm": "^0.39.1",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",


### PR DESCRIPTION
## Summary
- add **date-fns-tz** dependency
- use `formatInTimeZone` in `formatDate`

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685073f1fa7c8324a3b73d8d1e97654d