### PR TITLE
Introduce time entry schemas and payroll utilities

### DIFF
--- a/server/lib/__tests__/payroll.spec.ts
+++ b/server/lib/__tests__/payroll.spec.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { calculateWeeklyOvertime, isHolidayEligible } from '../payroll'
+
+const baseEntry = {
+  id: 1,
+  employeeId: 1,
+  timeIn: new Date('2024-06-01T08:00:00Z').toISOString(),
+  timeOut: new Date('2024-06-01T16:00:00Z').toISOString(),
+  lunchMinutes: 30,
+  notes: null as any,
+}
+
+describe('calculateWeeklyOvertime', () => {
+  it('computes no overtime for 40 hours', () => {
+    const entries = Array.from({ length: 5 }).map((_, i) => ({
+      ...baseEntry,
+      id: i,
+      timeIn: new Date(`2024-06-${i+1}T08:00:00Z`).toISOString(),
+      timeOut: new Date(`2024-06-${i+1}T16:30:00Z`).toISOString(),
+    }))
+    const result = calculateWeeklyOvertime(entries as any, 0)
+    expect(result.regularHours).toBeCloseTo(40)
+    expect(result.overtimeHours).toBe(0)
+  })
+
+  it('computes overtime when weekly hours exceed 40', () => {
+    const entries = Array.from({ length: 6 }).map((_, i) => ({
+      ...baseEntry,
+      id: i,
+      timeIn: new Date(`2024-06-${i+1}T08:00:00Z`).toISOString(),
+      timeOut: new Date(`2024-06-${i+1}T17:00:00Z`).toISOString(),
+    }))
+    const result = calculateWeeklyOvertime(entries as any, 0)
+    expect(result.regularHours).toBeCloseTo(40)
+    expect(result.overtimeHours).toBeCloseTo(4)
+  })
+})
+
+describe('isHolidayEligible', () => {
+  it('returns true when hire date is more than 90 days before holiday', () => {
+    const hire = '2024-01-01'
+    const holiday = '2024-04-05'
+    expect(isHolidayEligible(hire, holiday)).toBe(true)
+  })
+  it('returns false when hire date less than 90 days', () => {
+    const hire = '2024-01-01'
+    const holiday = '2024-03-01'
+    expect(isHolidayEligible(hire, holiday)).toBe(false)
+  })
+})

--- a/server/lib/payroll.ts
+++ b/server/lib/payroll.ts
@@ -1,0 +1,41 @@
+import { startOfWeek, differenceInMinutes } from 'date-fns'
+import type { TimeEntry } from '@shared/schema'
+
+function hoursFromEntry(entry: TimeEntry): number {
+  if (!entry.timeOut) return 0
+  const start = new Date(entry.timeIn)
+  const end = new Date(entry.timeOut)
+  let minutes = (end.getTime() - start.getTime()) / 60000
+  if (minutes < 0) {
+    minutes += 24 * 60
+  }
+  if (entry.lunchMinutes && minutes / 60 >= 8) {
+    minutes -= entry.lunchMinutes
+  }
+  if (minutes < 0) minutes = 0
+  return Math.round((minutes / 60) * 100) / 100
+}
+
+export function calculateWeeklyOvertime(entries: TimeEntry[], weekStartsOn: number) {
+  const buckets = new Map<string, number>()
+  for (const e of entries) {
+    const week = startOfWeek(new Date(e.timeIn), { weekStartsOn })
+    const key = week.toISOString()
+    const hours = hoursFromEntry(e)
+    buckets.set(key, (buckets.get(key) || 0) + hours)
+  }
+  let regularHours = 0
+  let overtimeHours = 0
+  for (const hours of buckets.values()) {
+    regularHours += Math.min(hours, 40)
+    overtimeHours += Math.max(0, hours - 40)
+  }
+  return { regularHours, overtimeHours }
+}
+
+export function isHolidayEligible(hireDate: string | Date, holidayDate: string | Date): boolean {
+  const hire = typeof hireDate === 'string' ? new Date(hireDate) : hireDate
+  const holiday = typeof holidayDate === 'string' ? new Date(holidayDate) : holidayDate
+  const diff = differenceInMinutes(holiday, hire)
+  return diff >= 90 * 24 * 60
+}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -4,6 +4,10 @@ import {
   employees,
   payPeriods,
   timecards,
+  timeEntries,
+  ptoEntries,
+  reimbursementEntries,
+  miscHoursEntries,
   reimbursements,
   reports,
   type User,
@@ -16,6 +20,14 @@ import {
   type InsertPayPeriod,
   type Timecard,
   type InsertTimecard,
+  type InsertTimeEntry,
+  type TimeEntry,
+  type InsertPtoEntry,
+  type PtoEntry,
+  type InsertReimbursementEntry,
+  type ReimbursementEntry,
+  type InsertMiscHoursEntry,
+  type MiscHoursEntry,
   type Reimbursement,
   type InsertReimbursement,
   type Report,
@@ -57,6 +69,30 @@ export interface IStorage {
   getTimecard(id: number): Promise<Timecard | undefined>;
   updateTimecard(id: number, timecard: Partial<InsertTimecard>): Promise<Timecard>;
   deleteTimecard(id: number): Promise<void>;
+
+  // Time entry operations
+  createTimeEntry(entry: InsertTimeEntry): Promise<TimeEntry>;
+  getTimeEntriesByEmployee(employeeId: number, start?: string, end?: string): Promise<TimeEntry[]>;
+  updateTimeEntry(id: number, entry: Partial<InsertTimeEntry>): Promise<TimeEntry>;
+  deleteTimeEntry(id: number): Promise<void>;
+
+  // PTO entry operations
+  createPtoEntry(entry: InsertPtoEntry): Promise<PtoEntry>;
+  getPtoEntriesByEmployee(employeeId: number): Promise<PtoEntry[]>;
+  updatePtoEntry(id: number, entry: Partial<InsertPtoEntry>): Promise<PtoEntry>;
+  deletePtoEntry(id: number): Promise<void>;
+
+  // Misc reimbursement entry operations
+  createReimbursementEntry(entry: InsertReimbursementEntry): Promise<ReimbursementEntry>;
+  getReimbursementEntriesByEmployee(employeeId: number): Promise<ReimbursementEntry[]>;
+  updateReimbursementEntry(id: number, entry: Partial<InsertReimbursementEntry>): Promise<ReimbursementEntry>;
+  deleteReimbursementEntry(id: number): Promise<void>;
+
+  // Misc hours entry operations
+  createMiscHoursEntry(entry: InsertMiscHoursEntry): Promise<MiscHoursEntry>;
+  getMiscHoursEntriesByEmployee(employeeId: number): Promise<MiscHoursEntry[]>;
+  updateMiscHoursEntry(id: number, entry: Partial<InsertMiscHoursEntry>): Promise<MiscHoursEntry>;
+  deleteMiscHoursEntry(id: number): Promise<void>;
   
   // Reimbursement operations
   createReimbursement(reimbursement: InsertReimbursement): Promise<Reimbursement>;
@@ -355,6 +391,117 @@ export class DatabaseStorage implements IStorage {
 
   async deleteTimecard(id: number): Promise<void> {
     await db.delete(timecards).where(eq(timecards.id, id));
+  }
+
+  // Time entry operations
+  async createTimeEntry(entry: InsertTimeEntry): Promise<TimeEntry> {
+    const [newEntry] = await db.insert(timeEntries).values(entry).returning();
+    return newEntry;
+  }
+
+  async getTimeEntriesByEmployee(employeeId: number, start?: string, end?: string): Promise<TimeEntry[]> {
+    const conditions: any[] = [eq(timeEntries.employeeId, employeeId)];
+    if (start) conditions.push(gte(timeEntries.timeIn, new Date(start)));
+    if (end) conditions.push(lte(timeEntries.timeIn, new Date(end)));
+    return await db
+      .select()
+      .from(timeEntries)
+      .where(and(...conditions))
+      .orderBy(asc(timeEntries.timeIn));
+  }
+
+  async updateTimeEntry(id: number, entry: Partial<InsertTimeEntry>): Promise<TimeEntry> {
+    const [updated] = await db
+      .update(timeEntries)
+      .set(entry)
+      .where(eq(timeEntries.id, id))
+      .returning();
+    return updated;
+  }
+
+  async deleteTimeEntry(id: number): Promise<void> {
+    await db.delete(timeEntries).where(eq(timeEntries.id, id));
+  }
+
+  // PTO entry operations
+  async createPtoEntry(entry: InsertPtoEntry): Promise<PtoEntry> {
+    const [newEntry] = await db.insert(ptoEntries).values(entry).returning();
+    return newEntry;
+  }
+
+  async getPtoEntriesByEmployee(employeeId: number): Promise<PtoEntry[]> {
+    return await db
+      .select()
+      .from(ptoEntries)
+      .where(eq(ptoEntries.employeeId, employeeId))
+      .orderBy(asc(ptoEntries.entryDate));
+  }
+
+  async updatePtoEntry(id: number, entry: Partial<InsertPtoEntry>): Promise<PtoEntry> {
+    const [updated] = await db
+      .update(ptoEntries)
+      .set(entry)
+      .where(eq(ptoEntries.id, id))
+      .returning();
+    return updated;
+  }
+
+  async deletePtoEntry(id: number): Promise<void> {
+    await db.delete(ptoEntries).where(eq(ptoEntries.id, id));
+  }
+
+  // Reimbursement entry operations
+  async createReimbursementEntry(entry: InsertReimbursementEntry): Promise<ReimbursementEntry> {
+    const [newEntry] = await db.insert(reimbursementEntries).values(entry).returning();
+    return newEntry;
+  }
+
+  async getReimbursementEntriesByEmployee(employeeId: number): Promise<ReimbursementEntry[]> {
+    return await db
+      .select()
+      .from(reimbursementEntries)
+      .where(eq(reimbursementEntries.employeeId, employeeId))
+      .orderBy(desc(reimbursementEntries.entryDate));
+  }
+
+  async updateReimbursementEntry(id: number, entry: Partial<InsertReimbursementEntry>): Promise<ReimbursementEntry> {
+    const [updated] = await db
+      .update(reimbursementEntries)
+      .set(entry)
+      .where(eq(reimbursementEntries.id, id))
+      .returning();
+    return updated;
+  }
+
+  async deleteReimbursementEntry(id: number): Promise<void> {
+    await db.delete(reimbursementEntries).where(eq(reimbursementEntries.id, id));
+  }
+
+  // Misc hours entry operations
+  async createMiscHoursEntry(entry: InsertMiscHoursEntry): Promise<MiscHoursEntry> {
+    const [newEntry] = await db.insert(miscHoursEntries).values(entry).returning();
+    return newEntry;
+  }
+
+  async getMiscHoursEntriesByEmployee(employeeId: number): Promise<MiscHoursEntry[]> {
+    return await db
+      .select()
+      .from(miscHoursEntries)
+      .where(eq(miscHoursEntries.employeeId, employeeId))
+      .orderBy(asc(miscHoursEntries.entryDate));
+  }
+
+  async updateMiscHoursEntry(id: number, entry: Partial<InsertMiscHoursEntry>): Promise<MiscHoursEntry> {
+    const [updated] = await db
+      .update(miscHoursEntries)
+      .set(entry)
+      .where(eq(miscHoursEntries.id, id))
+      .returning();
+    return updated;
+  }
+
+  async deleteMiscHoursEntry(id: number): Promise<void> {
+    await db.delete(miscHoursEntries).where(eq(miscHoursEntries.id, id));
   }
 
   // Reimbursement operations


### PR DESCRIPTION
## Summary
- add `weekStartsOn` and `hireDate` fields to schema
- create new tables for `time_entries`, `pto_entries`, `reimbursement_entries`, and `misc_hours_entries`
- add insert schemas and types for the new tables
- implement server payroll utilities for overtime and holiday eligibility
- provide unit tests for the payroll utilities
- implement CRUD storage and routes for time entry-related tables

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e02396e888324a79749bc96fa87c1