### PR TITLE
Update summary hours and add shift delete

### DIFF
--- a/client/src/components/forms/EmployeePayPeriodForm.tsx
+++ b/client/src/components/forms/EmployeePayPeriodForm.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useLocation } from "wouter";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Trash2 } from "lucide-react";
 import { apiRequest } from "@/lib/queryClient";
 import { calculateHoursFromTimecard } from "@/lib/payrollUtils";
 import { getDayOfWeek } from "@/lib/dateUtils";
@@ -261,6 +262,19 @@ export function EmployeePayPeriodForm({ employeeId, payPeriod, employee: propEmp
     );
   };
 
+  const removeShift = (date: string, index: number) => {
+    setDays((prev) =>
+      prev.map((d) => {
+        if (d.date !== date) return d;
+        const shifts = d.shifts.filter((_, i) => i !== index);
+        return {
+          ...d,
+          shifts: shifts.length > 0 ? shifts : [{ timeIn: "", timeOut: "", lunch: 0 }],
+        };
+      })
+    );
+  };
+
   const calculateDayTotal = (day: DayEntry) => {
     return day.shifts.reduce((sum, s) => {
       const hrs = calculateHoursFromTimecard(s.timeIn, s.timeOut, s.lunch).totalHours;
@@ -497,14 +511,15 @@ export function EmployeePayPeriodForm({ employeeId, payPeriod, employee: propEmp
                 + Add Shift
               </Button>
             </div>
-            <div className="grid grid-cols-4 gap-2 text-xs font-medium text-muted-foreground mb-1">
+            <div className="grid grid-cols-5 gap-2 text-xs font-medium text-muted-foreground mb-1">
               <span>Time In</span>
               <span>Time Out</span>
               <span>Lunch</span>
               <span>Total</span>
+              <span></span>
             </div>
             {day.shifts.map((shift, idx) => (
-              <div key={idx} className="grid grid-cols-4 gap-2 mb-2">
+              <div key={idx} className="grid grid-cols-5 gap-2 mb-2">
                 <Input
                   type="time"
                   value={shift.timeIn}
@@ -521,8 +536,11 @@ export function EmployeePayPeriodForm({ employeeId, payPeriod, employee: propEmp
                   onChange={(e) => updateShift(day.date, idx, "lunch", parseInt(e.target.value) || 0)}
                   placeholder="Lunch"
                 />
-                <div className="flex items-center text-sm">
-                  {calculateHoursFromTimecard(shift.timeIn, shift.timeOut, shift.lunch).totalHours.toFixed(2)}h
+                <div className="flex items-center justify-between text-sm">
+                  <span>{calculateHoursFromTimecard(shift.timeIn, shift.timeOut, shift.lunch).totalHours.toFixed(2)}h</span>
+                  <Button size="sm" variant="ghost" onClick={() => removeShift(day.date, idx)} className="text-destructive">
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
                 </div>
               </div>
             ))}

--- a/client/src/pages/timecards.tsx
+++ b/client/src/pages/timecards.tsx
@@ -186,7 +186,7 @@ export default function Timecards() {
                           <thead className="bg-gray-50">
                             <tr>
                               <th className="p-2 text-left">Employee</th>
-                              <th className="p-2 text-right">Total Hours</th>
+                              <th className="p-2 text-right">Regular Hours</th>
                               <th className="p-2 text-right">OT Hours</th>
                               <th className="p-2 text-right">PTO</th>
                               <th className="p-2 text-right">Holiday</th>
@@ -209,6 +209,9 @@ export default function Timecards() {
                                 holidayHours: updates?.holidayHours ?? stats.holidayHours ?? 0,
                                 holidayWorkedHours: updates?.holidayWorkedHours ?? stats.holidayWorkedHours ?? 0
                               };
+                              const regularHours =
+                                (displayStats.totalHours ?? 0) -
+                                (displayStats.totalOvertimeHours ?? 0);
                               
                               return (
                                 <tr
@@ -220,7 +223,7 @@ export default function Timecards() {
                                     <div className="font-medium">{employee.firstName} {employee.lastName}</div>
                                     <div className="text-xs text-muted-foreground">{employee.position}</div>
                                   </td>
-                                  <td className="p-2 text-right">{displayStats.totalHours?.toFixed?.(2) ?? '0.00'}</td>
+                                  <td className="p-2 text-right">{regularHours.toFixed(2)}</td>
                                   <td className="p-2 text-right text-orange-600 font-medium">{displayStats.totalOvertimeHours?.toFixed?.(2) ?? '0.00'}</td>
                                   <td className="p-2 text-right">{displayStats.ptoHours?.toFixed?.(2) ?? '0.00'}h</td>
                                   <td className="p-2 text-right">{displayStats.holidayHours?.toFixed?.(2) ?? '0.00'}h</td>
@@ -249,6 +252,9 @@ export default function Timecards() {
                             holidayHours: updates?.holidayHours ?? stats.holidayHours ?? 0,
                             holidayWorkedHours: updates?.holidayWorkedHours ?? stats.holidayWorkedHours ?? 0
                           };
+                          const regularHours =
+                            (displayStats.totalHours ?? 0) -
+                            (displayStats.totalOvertimeHours ?? 0);
                           
                           return (
                             <Card 
@@ -268,6 +274,10 @@ export default function Timecards() {
                                   </div>
                                 </div>
                                 <div className="grid grid-cols-2 gap-2 text-xs">
+                                  <div className="flex justify-between">
+                                    <span className="text-muted-foreground">Reg:</span>
+                                    <span>{regularHours.toFixed(2)}h</span>
+                                  </div>
                                   <div className="flex justify-between">
                                     <span className="text-muted-foreground">OT:</span>
                                     <span className="text-orange-600 font-medium">{displayStats.totalOvertimeHours?.toFixed?.(2) ?? '0.00'}h</span>


### PR DESCRIPTION
## Summary
- display Regular Hours instead of Total Hours on pay period summary
- calculate regular hours for mobile and desktop views
- allow deleting individual shifts in timecard entry form

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860308649e88324940a5a9aa36c67f2