### PR TITLE
Implement dashboard refresh after saving timecard

### DIFF
--- a/client/src/components/forms/EmployeePayPeriodForm.tsx
+++ b/client/src/components/forms/EmployeePayPeriodForm.tsx
@@ -456,12 +456,16 @@ export function EmployeePayPeriodForm({ employeeId, payPeriod, employee: propEmp
         description: "Timecard data saved successfully",
       });
 
-      // Prefetch updated dashboard stats for a snappier transition
       if (employee?.employerId) {
+        // Ensure dashboard stats refresh when returning to the main page
+        await queryClient.invalidateQueries({
+          queryKey: ["/api/dashboard/stats", employee.employerId],
+        });
+
         await queryClient.prefetchQuery({
           queryKey: ["/api/dashboard/stats", employee.employerId],
           queryFn: () =>
-            apiRequest("GET", `/api/dashboard/stats/${employee.employerId}`).then(res => res.json()),
+            apiRequest("GET", `/api/dashboard/stats/${employee.employerId}`).then((res) => res.json()),
         });
       }
 


### PR DESCRIPTION
## Summary
- refresh dashboard stats after saving employee timecard so that pay period summary shows fresh data when navigating back to the dashboard

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603470bfec8324b673122d953fef63