### PR TITLE
Fix pagination for payroll summary PDF

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1256,7 +1256,8 @@ async function generatePDFReport(
     doc.text(`$${periodReimb.toFixed(2)}`, 620, yPos);
     yPos += 15;
     
-    if (yPos > 700) {
+    // Start a new page before hitting the bottom of the page
+    if (yPos > doc.page.height - 50) {
       doc.addPage();
       yPos = addHeader();
     }


### PR DESCRIPTION
## Summary
- adjust page break check in payroll summary PDF generator

## Testing
- `npm test` *(fails: Failed to resolve import)*
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_6860359bec188324ba2f8e0370764a30