### PR TITLE
Fix PDF report page break threshold

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1155,6 +1155,7 @@ async function generatePDFReport(
 ) {
   const doc = new PDFDocument({ size: 'A4', layout: 'landscape' });
   doc.pipe(fs.createWriteStream(filePath));
+  let bottomThreshold = doc.page.height - 50;
 
   const addHeader = () => {
     // Report title and meta
@@ -1223,8 +1224,9 @@ async function generatePDFReport(
     yPos += 15;
     
     // Start a new page before hitting the bottom of the page
-    if (yPos > doc.page.height - 50) {
+    if (yPos > bottomThreshold) {
       doc.addPage({ size: 'A4', layout: 'landscape' });
+      bottomThreshold = doc.page.height - 50;
       yPos = addHeader();
     }
   }


### PR DESCRIPTION
## Summary
- fix PDF report page break threshold by using a dynamic variable

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run check` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68604290782c832483bb8620ea314a96