### PR TITLE
Add employer deletion API

### DIFF
--- a/client/src/pages/employees.tsx
+++ b/client/src/pages/employees.tsx
@@ -70,11 +70,19 @@ export default function Employees() {
 
 
   // Filter employees
-  const filteredEmployees = employees?.filter((emp: any) =>
-    `${emp.firstName} ${emp.lastName}`.toLowerCase().includes(searchTerm.toLowerCase()) ||
-    (emp.position || "").toLowerCase().includes(searchTerm.toLowerCase()) ||
-    (emp.email || "").toLowerCase().includes(searchTerm.toLowerCase())
-  ) || [];
+  const filteredEmployees = Array.isArray(employees)
+    ? employees.filter((emp: any) =>
+        `${emp.firstName} ${emp.lastName}`
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase()) ||
+        (emp.position || "")
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase()) ||
+        (emp.email || "")
+          .toLowerCase()
+          .includes(searchTerm.toLowerCase())
+      )
+    : [];
 
   const handleEdit = (employee: any) => {
     setEditingEmployee(employee);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -160,6 +160,23 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.delete('/api/employers/:id', isAuthenticated, async (req: any, res) => {
+    try {
+      const employerId = parseInt(req.params.id);
+      const employer = await storage.getEmployer(employerId);
+
+      if (!employer || employer.ownerId !== req.user.claims.sub) {
+        return res.status(403).json({ message: 'Access denied' });
+      }
+
+      await storage.deleteEmployer(employerId);
+      res.json({ message: 'Employer deleted successfully' });
+    } catch (error) {
+      console.error('Error deleting employer:', error);
+      res.status(500).json({ message: 'Failed to delete employer' });
+    }
+  });
+
   // Employee routes
   app.post('/api/employees', isAuthenticated, async (req: any, res) => {
     try {


### PR DESCRIPTION
## Summary
- add `deleteEmployer` method in storage for cascade deletion
- expose DELETE `/api/employers/:id` route
- guard against non-array responses when filtering employees

## Testing
- `npm test` *(fails: Failed to resolve import)*
- `npm run check` *(fails: multiple TypeScript errors)*)

------
https://chatgpt.com/codex/tasks/task_e_6860421b0b4c8324ac7f46da9f539d8b