### PR TITLE
Add company delete option to admin page

### DIFF
--- a/client/src/pages/admin/Companies.tsx
+++ b/client/src/pages/admin/Companies.tsx
@@ -6,7 +6,8 @@ import { Sidebar } from "@/components/layout/sidebar";
 import { Header } from "@/components/layout/header";
 import { EmployerForm } from "@/components/employer-form";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Plus } from "lucide-react";
+import { Plus, Trash2 } from "lucide-react";
+import { apiRequest } from "@/lib/queryClient";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 
@@ -20,6 +21,19 @@ export default function CompaniesAdmin() {
   const { data: employers = [] } = useQuery<any[]>({
     queryKey: ["/api/employers"],
     enabled: !!user,
+  });
+
+  const deleteCompanyMutation = useMutation({
+    mutationFn: async (id: number) => {
+      await apiRequest("DELETE", `/api/employers/${id}`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/employers"] });
+      toast({ title: "Success", description: "Company deleted successfully" });
+    },
+    onError: (error: Error) => {
+      toast({ title: "Error", description: error.message, variant: "destructive" });
+    }
   });
 
   const handleClose = () => {
@@ -49,7 +63,22 @@ export default function CompaniesAdmin() {
                 {employers.map((e:any) => (
                   <li key={e.id} className="flex justify-between border-b pb-2">
                     <span>{e.name}</span>
-                    <Button variant="outline" size="sm" onClick={() => { setEditing(e); setShowForm(true); }}>Edit</Button>
+                    <div className="space-x-2">
+                      <Button variant="outline" size="sm" onClick={() => { setEditing(e); setShowForm(true); }}>Edit</Button>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className="text-destructive"
+                        onClick={() => {
+                          if (window.confirm(`Are you sure you want to delete ${e.name}?`)) {
+                            deleteCompanyMutation.mutate(e.id);
+                          }
+                        }}
+                        disabled={deleteCompanyMutation.isPending}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Summary
- add API helper import and Trash2 icon
- add mutation to delete companies
- provide Delete button next to Edit on companies admin page

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860461325e88324aa209b7afef8e0dc