### PR TITLE
Add company delete option to admin page

### DIFF
--- a/client/src/context/company.tsx
+++ b/client/src/context/company.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useEffect, useState } from "react";
 
 interface CompanyContextProps {
   employerId: number | null;
-  setEmployerId: (id: number) => void;
+  setEmployerId: (id: number | null) => void;
 }
 
 const CompanyContext = createContext<CompanyContextProps | undefined>(undefined);
@@ -15,9 +15,13 @@ export function CompanyProvider({ children }: { children: React.ReactNode }) {
     if (stored) setEmployerIdState(parseInt(stored));
   }, []);
 
-  const setEmployerId = (id: number) => {
+  const setEmployerId = (id: number | null) => {
     setEmployerIdState(id);
-    localStorage.setItem("employerId", id.toString());
+    if (id === null) {
+      localStorage.removeItem("employerId");
+    } else {
+      localStorage.setItem("employerId", id.toString());
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- add API helper import and Trash2 icon
- add mutation to delete companies
- provide Delete button next to Edit on companies admin page
- update company context to allow clearing employer id
- update delete mutation to remove company from cache and clear selection

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860461325e88324aa209b7afef8e0dc