### PR TITLE
Sync overtime calc and optimistic UI

### DIFF
--- a/client/src/components/timecard-modal.tsx
+++ b/client/src/components/timecard-modal.tsx
@@ -33,7 +33,7 @@ export function TimecardModal({ isOpen, onClose, employee, timecards, payPeriod,
     totalRegularHours: employeeStats.regularHours || 0,
     totalOvertimeHours: employeeStats.overtimeHours || 0,
     totalHours: (employeeStats.regularHours || 0) + (employeeStats.overtimeHours || 0)
-  } : calculateWeeklyHours(timecards);
+  } : calculateWeeklyHours(timecards, payPeriod.startDate || payPeriod.start);
 
   const approveTimecardsMutation = useMutation({
     mutationFn: async () => {


### PR DESCRIPTION
## Summary
- align client overtime calculations with server logic
- compute optimistic dashboard updates using unified overtime function
- use pay period start date when showing timecard weekly totals

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605f356d908324878025af2b06bf8f